### PR TITLE
FreeCADWeb.Org ➞ FreeCAD.Org

### DIFF
--- a/CAD-tools.md
+++ b/CAD-tools.md
@@ -3,7 +3,7 @@
 ### Open source 
 #### GUI
 ##### FreeCAD
-[Site](https://www.freecadweb.org/)
+[Site](https://freecad.org)
 [Github](https://github.com/FreeCAD/FreeCAD)
 ![](images/freecad.jpg)
 

--- a/CAM-tools-CNC.md
+++ b/CAM-tools-CNC.md
@@ -56,7 +56,7 @@ https://github.com/ryannining/karyacnc
 ![](images/PyCAM.png)
 
 #### FreeCAD Path Workbench
-[Site](https://wiki.freecadweb.org/Path_Workbench)
+[Site](https://wiki.freecad.org/Path_Workbench)
 ![](images/FreeCADPath.png)
 
 #### Blender CAM


### PR DESCRIPTION
This PR updates references to the  
old FreeCAD website with new ones.